### PR TITLE
Create education event type

### DIFF
--- a/app/forms/AddEventFormFactory.php
+++ b/app/forms/AddEventFormFactory.php
@@ -14,8 +14,6 @@ use \Vodacek\Forms\Controls\DateInput;
 
 class AddEventFormFactory extends FormFactory
 {
-
-
     public function create()
     {
 
@@ -49,6 +47,8 @@ class AddEventFormFactory extends FormFactory
         $form->addSubmit('send', 'Vytvořit akci');
 
         $form->addHidden('event_id');
+
+        $form->addHidden('event_type');
 
         $form->getElementPrototype()->onsubmit('tinyMCE.triggerSave()');
         

--- a/app/model/EventFacade.php
+++ b/app/model/EventFacade.php
@@ -90,10 +90,11 @@ class EventFacade
         return $this->getEventRepository()->get($eventId);
     }
 
-    public function addEvent($userId, $title, $date_from, $date_to, $location, $description = null)
+    public function addEvent($userId, $eventType, $title, $date_from, $date_to, $location, $description = null)
     {
 
         $data = array('user_id'     => $userId,
+                      'event_type'  => $eventType,
                       'title'       => $title,
                       'date_from'   => $date_from,
                       'date_to'     => $date_to,
@@ -220,10 +221,13 @@ class EventFacade
         $this->getThreadRepository()->findBy('event_id', $eventId)->delete();
     }
 
-    public function getNewEventsCount($userId)
+    public function getNewEventsCount($userId, $eventType)
     {
         $user = $this->getProfileRepository()->get($userId);
-        return $this->getEventRepository()->findBy('created_at > ?', $user->last_activity)->count();
+        return $this->getEventRepository()
+                    ->findBy('created_at > ?', $user->last_activity)
+                    ->where('event_type = ?', $eventType)
+                    ->count();
     }
 
     /**********************

--- a/app/model/EventRepository.php
+++ b/app/model/EventRepository.php
@@ -18,6 +18,8 @@ class EventRepository extends Repository
     const BY_DATE_CREATED = 'created_at',
         BY_DATE_FROM = 'upcoming';
 
+    const EVENT_PUBLIC = 'public';
+    const EVENT_EDUCATION = 'education';
 
     public static function getOrderFunction($orderBy = 'last_post',$desc = true) {
         $ascDesc = $desc ? 'DESC' : 'ASC';

--- a/app/presenters/BaseSecurePresenter.php
+++ b/app/presenters/BaseSecurePresenter.php
@@ -4,6 +4,7 @@ namespace App\Presenters;
 use App\Model\ProfileRepository;
 use Nette;
 use App\Model;
+use App\Model\EventRepository;
 
 abstract class BaseSecurePresenter extends BasePresenter
 {
@@ -58,8 +59,13 @@ abstract class BaseSecurePresenter extends BasePresenter
             $this->flashMessage('Nestihli jsme tě ještě schválit, vydrž!', 'warning');
         }
 
-        $this->template->readLaterEventThreadsCount = $this->threadFacade->getReadLaterThreadsCount($this->user->id, true);
-        $this->template->newEventsCount = $c3 = $this->eventFacade->getNewEventsCount($this->user->id);
+        $this->template->readLaterEventThreadsCount = 
+            $this->threadFacade->getReadLaterThreadsCount($this->user->id, true);
+        $this->template->newPublicEventsCount = $cEvPub = 
+            $this->eventFacade->getNewEventsCount($this->user->id, EventRepository::EVENT_PUBLIC);
+        $this->template->newEduEventsCount = $cEvEdu = 
+            $this->eventFacade->getNewEventsCount($this->user->id, EventRepository::EVENT_EDUCATION);
+        $c3 = $cEvPub + $cEvEdu;
 
         $this->template->unreadThreadsCount = $c1 = $this->threadFacade->getUnreadThreadsCount($this->user->id);
         $this->template->unreadEventThreadsCount = $c2 = $this->threadFacade->getUnreadThreadsCount($this->user->id, true);

--- a/app/templates/@layout.latte
+++ b/app/templates/@layout.latte
@@ -34,9 +34,13 @@
                     <img src="/images/logo.jpg" alt="DDM Trebic logo">
                 </a></li>
             {if $user->isInRole('member')}
-                <li n:class="$presenter->isLinkCurrent('Event:default') ? active"><a n:href="Event:default">
-                        <i class="glyphicon glyphicon-tower mr10"></i>Akce
-                        <span n:if="$newEventsCount > 0" class="badge">{$newEventsCount}</span>
+                <li n:class="$presenter->isLinkCurrent('Event:listPublic') ? active"><a n:href="Event:listPublic">
+                        <i class="glyphicon glyphicon-tower mr10"></i>Naše Akce
+                        <span n:if="$newPublicEventsCount > 0" class="badge">{$newPublicEventsCount}</span>
+                    </a></li>
+                <li n:class="$presenter->isLinkCurrent('Event:listEducation') ? active"><a n:href="Event:listEducation">
+                        <i class="glyphicon glyphicon-education mr10"></i>Vzdělávací Akce
+                        <span n:if="$newEduEventsCount > 0" class="badge">{$newEduEventsCount}</span>
                     </a></li>
                 <li n:class="$presenter->isLinkCurrent('Event:calendar') ? active"><a n:href="Event:calendar">
                         <i class="glyphicon glyphicon-calendar mr10"></i>Kalendář</a></li>
@@ -97,7 +101,8 @@
                         <span n:snippet="badgeMobileAll">
                         {if $user->isLoggedIn()}
                             <button id="menu-toggle" type="button" class="btn btn-default visible-xs">
-                        {var newCount = $newEventsCount + $unreadThreadsCount + $unreadEventThreadsCount}
+                        {var newCount = $newPublicEventsCount + $newEduEventsCount + 
+                                        $unreadThreadsCount + $unreadEventThreadsCount}
                                 {if $newCount > 0}
                                     <span class="badge red">{$newCount}</span>
                             {else}

--- a/app/templates/Event/default.latte
+++ b/app/templates/Event/default.latte
@@ -1,10 +1,19 @@
 {block content}
-    <h1 class="page-header" n:block="title">Seznam akcí</h1>
+    <h1 class="page-header" n:block="title">
+        {switch $eventType}
+            {case public}
+                Akce Klubu
+            {case education}
+                Vzdělávací akce
+            {default}
+                Seznam akcí
+        {/switch}
+    </h1>
     {if $user->isInRole('add-event') }
-        <a class="btn btn-default" n:href="Event:create"><i class="glyphicon glyphicon-plus mr10"></i>Přidat akci</a>
+        <a class="btn btn-default" n:href="Event:create $eventType"><i class="glyphicon glyphicon-plus mr10"></i>Přidat akci</a>
     {/if}
 
-    <a n:href="Event:default $showLinkType"
+    <a n:href="Event:default $eventType, $showLinkType"
             class="btn btn-default">Zobrazit {$showLinkType ? 'všechny' : 'jen budoucí'}</a>
     <a class="btn btn-link pull-right" n:href="Event:exportCalendar">Přidat akce do Google Kalendáře</a>
     <hr>

--- a/app/templates/Event/show.latte
+++ b/app/templates/Event/show.latte
@@ -1,7 +1,7 @@
 {block content}
     <h1 class="page-header" n:block="title">{$event->title}</h1>
 
-    <a n:href="Event:default" class="btn btn-default"><i class="glyphicon glyphicon-chevron-left mr10"></i>Seznam
+    <a n:href="Event:list $event->event_type" class="btn btn-default"><i class="glyphicon glyphicon-chevron-left mr10"></i>Seznam
         akcí</a>
 
     <a class="btn btn-default" n:href="Event:calendar calendar-month=>$event->date_from->format('m'), calendar-year=>$event->date_from->format('Y'),do=>calendar-selection">

--- a/backup/migration_1.md
+++ b/backup/migration_1.md
@@ -1,0 +1,2 @@
+ALTER TABLE `event`
+	ADD COLUMN `event_type` VARCHAR(20) NULL DEFAULT 'public' AFTER `user_id`;


### PR DESCRIPTION
Nová třída akcí - vzdělávací akce typu CVVZ. Cokoli, co neorganizuje Klub, ale je relevantní na to upozorňovat ostatní.

Úpravy zahrnují na více místech rozlišení stávající funkcionality podle typu. Snažil jsem se omezení duplikace v `EventPresenter`, o routování se starají funkce `renderList<type>`, které ale pořád používají na pozadí `renderDefault`. Není to zrovna elegantní, možná se později pokusím o nějaký refaktoring.

Diskuze k akcím a kalendář se stále zobrazují dohromady, bez ohledu  na typ akce.

https://trello.com/c/qL08KvsX/3-p%C5%99idat-vzd%C4%9Bl%C3%A1vac%C3%AD-akce¨

![image](https://user-images.githubusercontent.com/11004597/197067449-a2e2dc1e-ed4d-4550-be2b-a6851a9751f1.png)
